### PR TITLE
Fix tp2_target handling in ChangeStageModal (fix #64)

### DIFF
--- a/interface/src/lib/components/Telemetry/ChangeStageModal.svelte
+++ b/interface/src/lib/components/Telemetry/ChangeStageModal.svelte
@@ -78,6 +78,9 @@
 		if (telemetry.tp1_target !== undefined && tp1_target !== telemetry.tp1_target) {
 			tasks.push(updateSetting('s_temp', tp1_target));
 		}
+		if (telemetry.tp2_target !== undefined && tp2_target !== telemetry.tp2_target) {
+			tasks.push(updateSetting('s_temp', tp2_target));
+		}
 		if (telemetry.hysteresis !== undefined && hysteresis !== telemetry.hysteresis) {
 			tasks.push(updateSetting('s_hyst', hysteresis));
 		}


### PR DESCRIPTION
  Исправление обработки целевой температуры ТД2 для firmware 2.6.0.

  - В `ChangeStageModal.svelte` добавлена обработка изменения `tp2_target`.
  - При изменении целевой температуры ТД2 значение теперь отправляется на контроллер как `s_temp` через `updateSetting`.

  Fixes #64.