### PR TITLE
fix(frontend): remove nested glassmorphism, single border/shadow on outer container

### DIFF
--- a/interface/src/lib/components/OCSettings/SensorsSettings.svelte
+++ b/interface/src/lib/components/OCSettings/SensorsSettings.svelte
@@ -129,12 +129,11 @@
 		width: 100%;
 	}
 
-	/* ===== ПАНЕЛЬ ЗОНЫ (.zone-panel) ===== */
+	/* ===== ПАНЕЛЬ ЗОНЫ (.zone-panel) — одна рамка/тень от glassmorphism (issue #119) ===== */
 	.zone-panel {
 		@include m.glassmorphism;
 		border-radius: 1rem;
 		overflow: hidden;
-		border: var(--glass-border);
 
 		@media (prefers-color-scheme: dark) {
 			background-color: var(--dark-surface-color);

--- a/interface/src/lib/styles/components/_setting-containers.scss
+++ b/interface/src/lib/styles/components/_setting-containers.scss
@@ -1,14 +1,13 @@
 @use "$lib/styles/base/variables" as v;
 @use "$lib/styles/base/mixins" as m;
 
+/* Обёртка группы настроек — без своей тени/рамки при вложении в .settings-container (issue #119) */
 .settings-group {
-  @include m.glassmorphism;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   padding: 1rem 1.25rem;
   border-radius: 1rem;
-  border: var(--glass-border);
 
   @media (prefers-color-scheme: dark) {
     background-color: var(--dark-surface-color);

--- a/interface/src/lib/styles/layout/_settings-grid.scss
+++ b/interface/src/lib/styles/layout/_settings-grid.scss
@@ -13,13 +13,11 @@
   border-radius: var(--border-radius);
 }
 
+/* Внутренняя обёртка — без своей тени/рамки, только компоновка (issue #119) */
 .settings-panel {
-  background: var(--glass-background);
-  border: var(--glass-border);
+  background: transparent;
   border-radius: var(--border-radius);
-  backdrop-filter: blur(8px);
   overflow: hidden;
-  box-shadow: var(--glass-shadow);
 }
 
 .settings-section {
@@ -32,7 +30,7 @@
 }
 
 .settings-grid {
-  @include m.glassmorphism;
+
   position: relative;
   width: auto;
   margin: 0;

--- a/interface/src/routes/oc/telemetry/Ssvc.svelte
+++ b/interface/src/routes/oc/telemetry/Ssvc.svelte
@@ -345,8 +345,8 @@
             .stage-controls {
               flex: 1;
 
+              /* Без своей тени/рамки — панель уже в .glassmorphism.panel (issue #119) */
               .valves-block {
-                @include glassmorphism;
                 border-radius: var(--border-radius);
 
                 &:not(:last-child) {


### PR DESCRIPTION
- _settings-grid: .settings-panel as transparent layout wrapper, no extra glass
- _setting-containers: remove glassmorphism from .settings-group when nested
- SensorsSettings: remove duplicate border on .zone-panel
- Ssvc.svelte: remove glass from .valves-block (parent .glassmorphism.panel already has it)

Fixes #119