### PR TITLE
Fix secure env macro duplication and relay coordinator build error

### DIFF
--- a/lib/ssvcOpenConnect/core/RelayPortCoordinator/RelayPortCoordinator.h
+++ b/lib/ssvcOpenConnect/core/RelayPortCoordinator/RelayPortCoordinator.h
@@ -58,6 +58,7 @@ private:
   uint8_t alarmMask() const;
   uint8_t userMaskChip0() const { return static_cast<uint8_t>(~alarmMask() & 0xFF); }
   uint8_t buildAlarmByte(AlarmLevel level) const;
+  uint8_t effectiveShadowChipLocked(unsigned chipIndex) const;
 
   std::vector<Pcf8574RelayPort> _ports;
   std::vector<uint8_t> _addresses;

--- a/platformio.ini
+++ b/platformio.ini
@@ -98,7 +98,7 @@ lib_deps =
 
 	adafruit/Adafruit BMP5xx Library @ ^1.0.2
 
-[env:esp32-s3-devkitc-1-8m]
+[common_esp32-s3-devkitc-1-8m]
 board = esp32-s3-devkitc-1-n8r2
 board_build.mcu = esp32s3
 board_build.partitions = default_8MB.csv
@@ -106,18 +106,33 @@ board_build.arduino.memory_type = qio_opi
 board_upload.before_reset = usb_reset
 build_flags = 
 	${env.build_flags}
-	-DFT_SECURITY=0
 	-DSSVC_OPEN_CONNECT_UART_TX=GPIO_NUM_17
 	-DSSVC_OPEN_CONNECT_UART_RX=GPIO_NUM_18
 debug_tool = esp-builtin
 
-[env:esp32-s3-devkitc-1-8m-secure]
-extends = env:esp32-s3-devkitc-1-8m
+[env:esp32-s3-devkitc-1-8m]
+board = ${common_esp32-s3-devkitc-1-8m.board}
+board_build.mcu = ${common_esp32-s3-devkitc-1-8m.board_build.mcu}
+board_build.partitions = ${common_esp32-s3-devkitc-1-8m.board_build.partitions}
+board_build.arduino.memory_type = ${common_esp32-s3-devkitc-1-8m.board_build.arduino.memory_type}
+board_upload.before_reset = ${common_esp32-s3-devkitc-1-8m.board_upload.before_reset}
+debug_tool = ${common_esp32-s3-devkitc-1-8m.debug_tool}
 build_flags =
-	${env:esp32-s3-devkitc-1-8m.build_flags}
+	${common_esp32-s3-devkitc-1-8m.build_flags}
+	-DFT_SECURITY=0
+
+[env:esp32-s3-devkitc-1-8m-secure]
+board = ${common_esp32-s3-devkitc-1-8m.board}
+board_build.mcu = ${common_esp32-s3-devkitc-1-8m.board_build.mcu}
+board_build.partitions = ${common_esp32-s3-devkitc-1-8m.board_build.partitions}
+board_build.arduino.memory_type = ${common_esp32-s3-devkitc-1-8m.board_build.arduino.memory_type}
+board_upload.before_reset = ${common_esp32-s3-devkitc-1-8m.board_upload.before_reset}
+debug_tool = ${common_esp32-s3-devkitc-1-8m.debug_tool}
+build_flags =
+	${common_esp32-s3-devkitc-1-8m.build_flags}
 	-DFT_SECURITY=1
 
-[env:esp32-s3-devkitc-1-16m]
+[common_esp32-s3-devkitc-1-16m]
 board = esp32-s3-devkitc-1-n16r8v
 board_build.mcu = esp32s3
 board_build.partitions = default_16MB.csv
@@ -125,17 +140,32 @@ board_build.arduino.memory_type = qio_opi
 board_upload.before_reset = usb_reset
 build_flags = 
 	${env.build_flags}
-	-DFT_SECURITY=0
 debug_tool = esp-builtin
 
-[env:esp32-s3-devkitc-1-16m-secure]
-extends = env:esp32-s3-devkitc-1-16m
+[env:esp32-s3-devkitc-1-16m]
+board = ${common_esp32-s3-devkitc-1-16m.board}
+board_build.mcu = ${common_esp32-s3-devkitc-1-16m.board_build.mcu}
+board_build.partitions = ${common_esp32-s3-devkitc-1-16m.board_build.partitions}
+board_build.arduino.memory_type = ${common_esp32-s3-devkitc-1-16m.board_build.arduino.memory_type}
+board_upload.before_reset = ${common_esp32-s3-devkitc-1-16m.board_upload.before_reset}
+debug_tool = ${common_esp32-s3-devkitc-1-16m.debug_tool}
 build_flags =
-	${env:esp32-s3-devkitc-1-16m.build_flags}
+	${common_esp32-s3-devkitc-1-16m.build_flags}
+	-DFT_SECURITY=0
+
+[env:esp32-s3-devkitc-1-16m-secure]
+board = ${common_esp32-s3-devkitc-1-16m.board}
+board_build.mcu = ${common_esp32-s3-devkitc-1-16m.board_build.mcu}
+board_build.partitions = ${common_esp32-s3-devkitc-1-16m.board_build.partitions}
+board_build.arduino.memory_type = ${common_esp32-s3-devkitc-1-16m.board_build.arduino.memory_type}
+board_upload.before_reset = ${common_esp32-s3-devkitc-1-16m.board_upload.before_reset}
+debug_tool = ${common_esp32-s3-devkitc-1-16m.debug_tool}
+build_flags =
+	${common_esp32-s3-devkitc-1-16m.build_flags}
 	-DFT_SECURITY=1
 
 
-[env:kincony-kc868-a6]
+[common_kincony-kc868-a6]
 ; Same flash/partition as 16m devkit, but pinout for KC868-A6 v6 (no WLED 38/40 — used by LoRa CS / nRF CE on PCB).
 board = esp32-s3-devkitc-1-n16r8v
 board_build.mcu = esp32s3
@@ -145,7 +175,6 @@ board_upload.before_reset = usb_reset
 ; KC868-A6 rev. v6: RS485 TX=17 RX=18; 1-Wire1=15 / 1-Wire2=16; I2C SDA=12 SCL=11; PCF8574 in=0x22 relay=0x24; GP8403=0x58.
 build_flags =
 	${env.build_flags}
-	-DFT_SECURITY=0
 	-D PINOUT_USE_GPIO=0
 	-DBOARD_KINCONY_KC868_A6=1
 	-DSSVC_OPEN_CONNECT_UART_TX=GPIO_NUM_17
@@ -155,11 +184,26 @@ build_flags =
 	-DSSVC_I2C_SCL_GPIO=11
 debug_tool = esp-builtin
 
+[env:kincony-kc868-a6]
+board = ${common_kincony-kc868-a6.board}
+board_build.mcu = ${common_kincony-kc868-a6.board_build.mcu}
+board_build.partitions = ${common_kincony-kc868-a6.board_build.partitions}
+board_build.arduino.memory_type = ${common_kincony-kc868-a6.board_build.arduino.memory_type}
+board_upload.before_reset = ${common_kincony-kc868-a6.board_upload.before_reset}
+debug_tool = ${common_kincony-kc868-a6.debug_tool}
+build_flags =
+	${common_kincony-kc868-a6.build_flags}
+	-DFT_SECURITY=0
 
 [env:kincony-kc868-a6-secure]
-extends = env:kincony-kc868-a6
+board = ${common_kincony-kc868-a6.board}
+board_build.mcu = ${common_kincony-kc868-a6.board_build.mcu}
+board_build.partitions = ${common_kincony-kc868-a6.board_build.partitions}
+board_build.arduino.memory_type = ${common_kincony-kc868-a6.board_build.arduino.memory_type}
+board_upload.before_reset = ${common_kincony-kc868-a6.board_upload.before_reset}
+debug_tool = ${common_kincony-kc868-a6.debug_tool}
 build_flags =
-	${env:kincony-kc868-a6.build_flags}
+	${common_kincony-kc868-a6.build_flags}
 	-DFT_SECURITY=1
 
 ; Native unit tests (run on host PC: pio test -e native)

--- a/platformio.ini
+++ b/platformio.ini
@@ -102,7 +102,7 @@ lib_deps =
 board = esp32-s3-devkitc-1-n8r2
 board_build.mcu = esp32s3
 board_build.partitions = default_8MB.csv
-board_build.arduino.memory_type = qio_opi
+board_build.arduino.memory_type = qio_qspi
 board_upload.before_reset = usb_reset
 build_flags = 
 	${env.build_flags}


### PR DESCRIPTION
## Summary
- remove duplicate `FT_SECURITY` macro definitions by introducing non-`env:` common PlatformIO sections and setting `FT_SECURITY` only in concrete build environments
- keep PlatformIO Tasks clean by avoiding `env:*common` helper environments
- fix `RelayPortCoordinator` compilation by declaring `effectiveShadowChipLocked(...)` in the class header

## Test plan
- [x] `platformio run --environment kincony-kc868-a6-secure`
- [x] `platformio run --target upload --target monitor --environment kincony-kc868-a6-secure`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hardware platform support for ESP32-S3 devkit (8MB variant).
  * Added hardware platform support for Kincony KC868-A6 device.

* **Chores**
  * Improved build configuration management and settings organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->