### PR TITLE
refactor(logging): reduce serial noise and set CORE_DEBUG_LEVEL=3

### DIFF
--- a/lib/ssvcOpenConnect/components/Led/StatusLed.cpp
+++ b/lib/ssvcOpenConnect/components/Led/StatusLed.cpp
@@ -56,11 +56,23 @@ void StatusLed::refreshLed(const char *phase) {
 
   if (uartErr) {
     const bool blinkOn = (millis() / 300) % 2 == 0;
-    _led->fill(blinkOn ? 0xFF8000 : 0x000000);
-    ESP_LOGI("StatusLed",
-             "[%s] UART error -> blink orange (phase=%s) [conn would be %s]",
-             phase, blinkOn ? "on" : "off",
-             connectionStatusLabel(currentStatus));
+    const uint32_t rgb = blinkOn ? 0xFF8000u : 0x000000u;
+    _led->fill(rgb);
+    const bool stateChanged =
+        !_lastUartErrValid || _lastUartErr != uartErr || !_lastRgbValid ||
+        _lastRgb != rgb;
+    if (stateChanged) {
+      ESP_LOGI("StatusLed",
+               "[%s] UART error -> blink orange (phase=%s) [conn would be %s]",
+               phase, blinkOn ? "on" : "off",
+               connectionStatusLabel(currentStatus));
+      _lastUartErr = uartErr;
+      _lastUartErrValid = true;
+      _lastRgb = rgb;
+      _lastRgbValid = true;
+      _lastConn = currentStatus;
+      _lastConnValid = true;
+    }
   } else {
     const char *mode = "";
     uint32_t rgb = 0;
@@ -86,11 +98,25 @@ void StatusLed::refreshLed(const char *phase) {
       mode = "white fallback";
     }
     _led->fill(rgb);
-    ESP_LOGI("StatusLed",
-             "[%s] connection=%s (%d) -> %s 0x%06lX",
-             phase, connectionStatusLabel(currentStatus),
-             static_cast<int>(currentStatus), mode,
-             static_cast<unsigned long>(rgb));
+    const bool stateChanged =
+        !_lastUartErrValid || _lastUartErr != uartErr || !_lastConnValid ||
+        _lastConn != currentStatus || !_lastRgbValid || _lastRgb != rgb;
+    if (stateChanged) {
+      ESP_LOGI("StatusLed",
+               "[%s] connection=%s (%d) -> %s 0x%06lX",
+               phase, connectionStatusLabel(currentStatus),
+               static_cast<int>(currentStatus), mode,
+               static_cast<unsigned long>(rgb));
+      _lastUartErr = uartErr;
+      _lastUartErrValid = true;
+      _lastConn = currentStatus;
+      _lastConnValid = true;
+      _lastRgb = rgb;
+      _lastRgbValid = true;
+    } else {
+      ESP_LOGV("StatusLed", "[%s] unchanged: %s", phase,
+               connectionStatusLabel(currentStatus));
+    }
   }
 
   _led->show();

--- a/lib/ssvcOpenConnect/components/Led/StatusLed.h
+++ b/lib/ssvcOpenConnect/components/Led/StatusLed.h
@@ -36,6 +36,13 @@ private:
   ESP32SvelteKit *_esp32sveltekit;
   Adafruit_NeoPixel *_led = nullptr;
 
+  bool _lastUartErr = false;
+  bool _lastUartErrValid = false;
+  ConnectionStatus _lastConn = ConnectionStatus::OFFLINE;
+  bool _lastConnValid = false;
+  uint32_t _lastRgb = 0;
+  bool _lastRgbValid = false;
+
   /** Синхронное обновление ленты + лог (вызывать из begin и из задачи). */
   void refreshLed(const char *phase);
 

--- a/lib/ssvcOpenConnect/core/AlarmMonitor/AlarmMonitor.cpp
+++ b/lib/ssvcOpenConnect/core/AlarmMonitor/AlarmMonitor.cpp
@@ -197,7 +197,7 @@ void AlarmMonitor::subscribe(IAlarmSubscriber* subscriber) {
     }
 
     if (added) {
-        ESP_LOGI(TAG, "Subscriber 0x%p successfully added. Total subscribers: %zu.",
+        ESP_LOGD(TAG, "Subscriber 0x%p successfully added. Total subscribers: %zu.",
                  static_cast<void*>(subscriber), subscriberCount);
     } else {
         ESP_LOGD(TAG, "Subscriber 0x%p is already subscribed. Skipping.", static_cast<void*>(subscriber));
@@ -306,8 +306,7 @@ void AlarmMonitor::checkAllSensors() {
         return;
     }
 
-    // Подробный лог о начале цикла проверки
-    ESP_LOGI(TAG, "Starting sensor check cycle.");
+    ESP_LOGV(TAG, "Starting sensor check cycle.");
 
     // 1. Получаем доступ к текущим настройкам порогов
     _thresholdService->read([&](const AlarmThresholdsState& thresholdsState) {
@@ -315,7 +314,7 @@ void AlarmMonitor::checkAllSensors() {
         // 2. Получаем все датчики
         const SensorManager& sm = SensorManager::getInstance();
         const auto& all_sensors = sm.getAllSensors();
-        ESP_LOGI(TAG, "Processing %zu sensors.", all_sensors.size());
+        ESP_LOGV(TAG, "Processing %zu sensors.", all_sensors.size());
 
         for (const auto& pair : all_sensors) {
             const std::string& addr_str = pair.first;
@@ -323,17 +322,17 @@ void AlarmMonitor::checkAllSensors() {
 
             // 3. Проверяем, есть ли для этого датчика настройки
             if (thresholdsState.sensor_thresholds.count(addr_str) == 0) {
-                ESP_LOGI(TAG, "Sensor %s skipped: No threshold settings found.", addr_str.c_str());
+                ESP_LOGD(TAG, "Sensor %s skipped: No threshold settings found.", addr_str.c_str());
                 continue; // Настроек нет, пропускаем
             }
 
             const ThresholdSettings& settings = thresholdsState.sensor_thresholds.at(addr_str);
             if (!settings.enabled) {
-                ESP_LOGI(TAG, "Sensor %s skipped: Monitoring is disabled.", addr_str.c_str());
+                ESP_LOGD(TAG, "Sensor %s skipped: Monitoring is disabled.", addr_str.c_str());
                 continue; // Мониторинг для датчика выключен
             }
             // Подробный лог с настройками
-            ESP_LOGI(TAG, "Sensor %s: Thresh (Crit:%.2f, Dang:%.2f, Min:%.2f).",
+            ESP_LOGV(TAG, "Sensor %s: Thresh (Crit:%.2f, Dang:%.2f, Min:%.2f).",
                      addr_str.c_str(), settings.critical_threshold, settings.dangerous_threshold, settings.min_threshold);
             // 4. Сравнение
             const float current_value = sensor->getData();
@@ -355,7 +354,7 @@ void AlarmMonitor::checkAllSensors() {
 
              if (is_first_check) {
                  // Инициализируем состояние как NORMAL, но не генерируем событие.
-                 ESP_LOGI(TAG, "Sensor %s is in initial state (non-valid data). Skipping alarm check.", addr_str.c_str());
+                 ESP_LOGD(TAG, "Sensor %s is in initial state (non-valid data). Skipping alarm check.", addr_str.c_str());
                  continue; // Пропускаем, чтобы избежать ложной тревоги MINIMUM
              }
 
@@ -394,7 +393,7 @@ void AlarmMonitor::checkAllSensors() {
             float threshold_crossed = 0.0f;
 
             // Логируем текущее значение
-            ESP_LOGI(TAG, "Sensor %s read value: %.2f.", addr_str.c_str(), current_value);
+            ESP_LOGV(TAG, "Sensor %s read value: %.2f.", addr_str.c_str(), current_value);
 
             // --- Логика определения уровня тревоги ---
             if (current_value >= settings.critical_threshold) {
@@ -439,11 +438,11 @@ void AlarmMonitor::checkAllSensors() {
 
             } else {
                 // Подробный лог, если состояние не изменилось
-                ESP_LOGI(TAG, "Sensor %s: State remains %d (Value: %.2f). No notification sent.",
+                ESP_LOGV(TAG, "Sensor %s: State remains %d (Value: %.2f). No notification sent.",
                          addr_str.c_str(), static_cast<int>(new_level), current_value);
             }
         }
     });
 
-    ESP_LOGD(TAG, "Sensor check cycle finished.");
+    ESP_LOGV(TAG, "Sensor check cycle finished.");
 }

--- a/lib/ssvcOpenConnect/core/GlobalConfig/GlobalConfig.h
+++ b/lib/ssvcOpenConnect/core/GlobalConfig/GlobalConfig.h
@@ -239,11 +239,11 @@ public:
 template<typename T>
 void setObject(const String& ns, const String& key, const T& obj, void (*toJson)(const T&, JsonObject&)) {
     std::lock_guard<std::mutex> lock(_mutex);
-    ESP_LOGD("Preferences", "Setting object in namespace '%s' with key '%s'", ns.c_str(), key.c_str());
+    ESP_LOGV("Preferences", "Setting object in namespace '%s' with key '%s'", ns.c_str(), key.c_str());
 
     Preferences prefs;
     if (!prefs.begin(ns.c_str(), false)) {
-        ESP_LOGD("Preferences", "Failed to begin namespace '%s'", ns.c_str());
+        ESP_LOGV("Preferences", "Failed to begin namespace '%s'", ns.c_str());
         return;
     }
 
@@ -253,18 +253,18 @@ void setObject(const String& ns, const String& key, const T& obj, void (*toJson)
 
     String newJsonStr;
     serializeJson(doc, newJsonStr);
-    ESP_LOGD("Preferences", "Serialized JSON: %s", newJsonStr.c_str());
+    ESP_LOGV("Preferences", "Serialized JSON: %s", newJsonStr.c_str());
 
     const String existing = prefs.getString(key.c_str(), "");
     if (existing != newJsonStr) {
-        ESP_LOGD("Preferences", "Value changed, updating preference");
+        ESP_LOGV("Preferences", "Value changed, updating preference");
         if (prefs.putString(key.c_str(), newJsonStr)) {
-            ESP_LOGD("Preferences", "Successfully saved preference");
+            ESP_LOGV("Preferences", "Successfully saved preference");
         } else {
-            ESP_LOGD("Preferences", "Failed to save preference");
+            ESP_LOGW("Preferences", "Failed to save preference");
         }
     } else {
-        ESP_LOGD("Preferences", "Value unchanged, skipping update");
+        ESP_LOGV("Preferences", "Value unchanged, skipping update");
     }
 
     prefs.end();
@@ -273,11 +273,11 @@ void setObject(const String& ns, const String& key, const T& obj, void (*toJson)
 template<typename T>
 bool getObject(const String& ns, const String& key, T& obj, void (*fromJson)(const JsonObject&, T&)) {
     std::lock_guard<std::mutex> lock(_mutex);
-    ESP_LOGD("Preferences", "Getting object from namespace '%s' with key '%s'", ns.c_str(), key.c_str());
+    ESP_LOGV("Preferences", "Getting object from namespace '%s' with key '%s'", ns.c_str(), key.c_str());
 
     Preferences prefs;
     if (!prefs.begin(ns.c_str(), true)) {
-        ESP_LOGD("Preferences", "Failed to begin namespace '%s'", ns.c_str());
+        ESP_LOGV("Preferences", "Failed to begin namespace '%s'", ns.c_str());
         return false;
     }
 
@@ -285,22 +285,22 @@ bool getObject(const String& ns, const String& key, T& obj, void (*fromJson)(con
     prefs.end();
 
     if (jsonStr.isEmpty()) {
-        ESP_LOGD("Preferences", "No data found for key '%s'", key.c_str());
+        ESP_LOGV("Preferences", "No data found for key '%s'", key.c_str());
         return false;
     }
 
-    ESP_LOGD("Preferences", "Retrieved JSON: %s", jsonStr.c_str());
+    ESP_LOGV("Preferences", "Retrieved JSON: %s", jsonStr.c_str());
 
     JsonDocument doc;
     DeserializationError error = deserializeJson(doc, jsonStr);
     if (error != DeserializationError::Ok) {
-        ESP_LOGD("Preferences", "JSON deserialization failed: %s", error.c_str());
+        ESP_LOGW("Preferences", "JSON deserialization failed: %s", error.c_str());
         return false;
     }
 
     const auto json = doc.as<JsonObject>();
     fromJson(json, obj);
-    ESP_LOGD("Preferences", "Successfully parsed object");
+    ESP_LOGV("Preferences", "Successfully parsed object");
     return true;
 }
 

--- a/lib/ssvcOpenConnect/core/SsvcCommandsQueue.cpp
+++ b/lib/ssvcOpenConnect/core/SsvcCommandsQueue.cpp
@@ -157,7 +157,7 @@ void SsvcCommandsQueue::commandProcessorTask(void *pvParameters) {
 
   while (true) {
     if (xQueueReceive(self->command_queue, &cmd, portMAX_DELAY) == pdPASS) {
-      ESP_LOGI(TAG, "Processing command of type: %d", cmd->type);
+      ESP_LOGD(TAG, "Processing command of type: %d", cmd->type);
       bool command_success = false;
 
       while (cmd->attempt_count != 0) {
@@ -204,7 +204,7 @@ void SsvcCommandsQueue::commandProcessorTask(void *pvParameters) {
               SsvcConnector::sendCommand(oss.str().c_str());
           break;
         }
-        ESP_LOGI(TAG, "Send result: %d", command_success);
+        ESP_LOGD(TAG, "Send result: %d", command_success);
 
         if (!command_success) {
           ESP_LOGE(TAG, "Failed to send command %d",
@@ -373,7 +373,7 @@ void SsvcCommandsQueue::pushCommandInQueue(const SsvcCommandType type,
     ESP_LOGE(TAG, "Failed to send command to queue! Queue might be full.");
     delete cmd;
   } else {
-    ESP_LOGI(TAG, "Command type %d enqueued successfully.", static_cast<int>(type));
+    ESP_LOGD(TAG, "Command type %d enqueued successfully.", static_cast<int>(type));
   }
 }
 
@@ -475,7 +475,7 @@ void SsvcCommandsQueue::at(const int attempt_count, const TickType_t timeout) co
 void SsvcCommandsQueue::set(const std::string& parameters, const int attempt_count,
                             const TickType_t timeout) const
 {
-  ESP_LOGI(TAG, "Set command called with parameters: %s", parameters.c_str());
+  ESP_LOGD(TAG, "Set command called with parameters: %s", parameters.c_str());
   pushCommandInQueue(SsvcCommandType::SET, parameters, attempt_count, timeout);
 }
 

--- a/lib/ssvcOpenConnect/core/SsvcOpenConnect.cpp
+++ b/lib/ssvcOpenConnect/core/SsvcOpenConnect.cpp
@@ -39,7 +39,8 @@ void SsvcOpenConnect::begin(AsyncWebServer& server,
                             EventSocket* socket,
                             SecurityManager* securityManager)
 {
-    ESP_LOGI(TAG, "begin: enter (server=%p svelte=%p socket=%p)",
+    ESP_LOGI(TAG, "begin: starting SSVC OpenConnect");
+    ESP_LOGD(TAG, "begin: enter (server=%p svelte=%p socket=%p)",
              static_cast<void*>(&server), static_cast<void*>(&esp32sveltekit),
              static_cast<void*>(socket));
 
@@ -49,14 +50,14 @@ void SsvcOpenConnect::begin(AsyncWebServer& server,
     _securityManager = securityManager;
     _mqttClient = _esp32sveltekit->getMqttClient();
 
-    ESP_LOGI(TAG, "begin: StatusLed");
+    ESP_LOGD(TAG, "begin: StatusLed");
     _statusLed = std::make_unique<StatusLed>(&esp32sveltekit);
     _statusLed->begin(NEO_GRB);
 
     _profileService = ProfileService::getInstance();
 
     // Инициализируем сервисы, которые являются наблюдателями, и подписываем их на ProfileService
-    ESP_LOGI(TAG, "begin: MQTT/Telegram/Alarm/Sensor services construct");
+    ESP_LOGD(TAG, "begin: MQTT/Telegram/Alarm/Sensor services construct");
     _ssvcMqttSettingsService = new SsvcMqttSettingsService(_server, _esp32sveltekit);
     _telegramSettingsService = new TelegramSettingsService(_server, _esp32sveltekit);
     TelegramSettingsService::setInstance(_telegramSettingsService);
@@ -75,10 +76,10 @@ void SsvcOpenConnect::begin(AsyncWebServer& server,
     _profileService->subscribe(_alarmThresholdService);
 
     // Теперь вызываем begin() для ProfileService
-    ESP_LOGI(TAG, "begin: ProfileService::begin");
+    ESP_LOGD(TAG, "begin: ProfileService::begin");
     _profileService->begin(_esp32sveltekit->getFS());
 
-    ESP_LOGI(TAG, "begin: OpenConnectHardwareSettingsService");
+    ESP_LOGD(TAG, "begin: OpenConnectHardwareSettingsService");
     OpenConnectHardwareSettingsService::instance().begin(_esp32sveltekit->getFS());
 
 #if !PINOUT_USE_GPIO
@@ -88,13 +89,13 @@ void SsvcOpenConnect::begin(AsyncWebServer& server,
 #endif
 
     // Теперь вызываем begin() для остальных сервисов
-    ESP_LOGI(TAG, "begin: Telegram/Alarm/SensorData/SensorConfig begin");
+    ESP_LOGD(TAG, "begin: Telegram/Alarm/SensorData/SensorConfig begin");
     _telegramSettingsService->begin();
     _alarmThresholdService->begin();
     _sensorDataService->begin();
     _sensorConfigService->begin();
 
-    ESP_LOGI(TAG, "begin: AlarmMonitor::initialize");
+    ESP_LOGD(TAG, "begin: AlarmMonitor::initialize");
     AlarmMonitor::getInstance().initialize(_alarmThresholdService);
 
     RelayRuleEngine::getInstance().begin();
@@ -106,13 +107,13 @@ void SsvcOpenConnect::begin(AsyncWebServer& server,
     _esp32sveltekit->getFeatureService()->addFeature(String("openConnectUserRelays"), true);
 #endif
 
-    ESP_LOGI(TAG, "begin: SensorCoordinator + OneWire (pin=%u)",
+    ESP_LOGD(TAG, "begin: SensorCoordinator + OneWire (pin=%u)",
              static_cast<unsigned>(OneWireThermalSubsystem::ONEWIRE_PIN));
     SensorCoordinator::getInstance().registerPollingSubsystem(
         &OneWireThermalSubsystem::getInstance()
     );
 
-    ESP_LOGI(TAG, "begin: SensorCoordinator::startPolling");
+    ESP_LOGD(TAG, "begin: SensorCoordinator::startPolling");
     SensorCoordinator::getInstance().startPolling(SENSOR_POLL_INTERVAL_MS);
 
     _sensorConfigService->addUpdateHandler([&](const String& originId) {
@@ -125,35 +126,35 @@ void SsvcOpenConnect::begin(AsyncWebServer& server,
         AlarmMonitor::getInstance().checkAllSensors();
     });
 
-    ESP_LOGI(TAG, "begin: Notification + hardware-fault log subscribers");
+    ESP_LOGD(TAG, "begin: Notification + hardware-fault log subscribers");
     _notificationSubscriber = new NotificationSubscriber(_esp32sveltekit);
     _hardwareFaultLogSubscriber = new HardwareFaultLogSubscriber();
 
-    ESP_LOGI(TAG, "begin: RectificationProcess::begin");
+    ESP_LOGD(TAG, "begin: RectificationProcess::begin");
     rProcess.begin(
       _ssvcConnector, _ssvcSettings, *_ssvcMqttSettingsService);
 
-    ESP_LOGI(TAG, "begin: TelemetryService");
+    ESP_LOGD(TAG, "begin: TelemetryService");
     _telemetryService = new TelemetryService(_server, _esp32sveltekit, rProcess);
     _telemetryService->begin();
 
-    ESP_LOGI(TAG, "begin: HttpRequestHandler");
+    ESP_LOGD(TAG, "begin: HttpRequestHandler");
     httpRequestHandler = std::make_unique<HttpRequestHandler>(*_server, _securityManager, _profileService, _esp32sveltekit->getFS());
     httpRequestHandler->begin();
 
-    ESP_LOGI(TAG, "begin: delay 2s then SSVC getSettings/version");
+    ESP_LOGD(TAG, "begin: delay 2s then SSVC getSettings/version");
     vTaskDelay(pdMS_TO_TICKS(2000));
     const SsvcCommandsQueue* queue = &SsvcCommandsQueue::getQueue();
     queue->getSettings();
     queue->version();
 
-    ESP_LOGI(TAG, "begin: MqttBridge + MqttCommandHandler");
+    ESP_LOGD(TAG, "begin: MqttBridge + MqttCommandHandler");
     MqttBridge::getInstance(_esp32sveltekit->getMqttSettingsService());
 
     const auto commandHandler = new MqttCommandHandler();
     commandHandler->begin();
 
-    ESP_LOGI(TAG, "begin: subsystemManager() (blocks until WiFi)");
+    ESP_LOGD(TAG, "begin: subsystemManager() (blocks until WiFi)");
     this->subsystemManager();
 
     ESP_LOGI(TAG, "begin: done");

--- a/lib/ssvcOpenConnect/core/SubsystemManager/SubsystemManager.h
+++ b/lib/ssvcOpenConnect/core/SubsystemManager/SubsystemManager.h
@@ -45,7 +45,7 @@ public:
         info.name = name;
         info.factory = []() { return std::make_shared<T>(); };
         _subsystems_info.push_back(std::move(info));
-        ESP_LOGI(TAG, "[REGISTER] %s registered successfully", name.c_str());
+        ESP_LOGD(TAG, "[REGISTER] %s registered successfully", name.c_str());
     }
 
     template<typename T>
@@ -60,7 +60,7 @@ public:
             return std::shared_ptr<T>(&T::getInstance(), [](T*){});
         };
         _subsystems_info.push_back(std::move(info));
-        ESP_LOGI(TAG, "[REGISTER] %s registered as Singleton", name.c_str());
+        ESP_LOGD(TAG, "[REGISTER] %s registered as Singleton", name.c_str());
     }
     
     void setInitialState(const std::string& name, bool enabled);

--- a/lib/ssvcOpenConnect/core/profiles/ProfileService.cpp
+++ b/lib/ssvcOpenConnect/core/profiles/ProfileService.cpp
@@ -120,13 +120,13 @@ String ProfileService::getCurrentTimestamp() {
 
 // Helper methods for metadata management
 bool ProfileService::_readMetadata(JsonDocument& doc) const {
-    ESP_LOGI(TAG, "_readMetadata: Entry. Path=%s", _metadataFilePath); // Логирование входа
+    ESP_LOGD(TAG, "_readMetadata: Entry. Path=%s", _metadataFilePath); // Логирование входа
     File metadataFile = _fs->open(_metadataFilePath, "r");
     if (!metadataFile) {
         ESP_LOGE(TAG, "_readMetadata: Failed to open metadata file for reading: %s", _metadataFilePath); // Логирование ошибки
         return false;
     }
-    ESP_LOGI(TAG, "_readMetadata: Metadata file opened: %s", _metadataFilePath); // Логирование открытия файла
+    ESP_LOGD(TAG, "_readMetadata: Metadata file opened: %s", _metadataFilePath); // Логирование открытия файла
 
     const DeserializationError error = deserializeJson(doc, metadataFile);
     metadataFile.close();
@@ -134,18 +134,18 @@ bool ProfileService::_readMetadata(JsonDocument& doc) const {
         ESP_LOGE(TAG, "_readMetadata: Failed to deserialize metadata file %s: %s", _metadataFilePath, error.c_str()); // Логирование ошибки
         return false;
     }
-    ESP_LOGI(TAG, "_readMetadata: Metadata deserialized successfully."); // Логирование десериализации
+    ESP_LOGD(TAG, "_readMetadata: Metadata deserialized successfully."); // Логирование десериализации
     return true;
 }
 
 bool ProfileService::_writeMetadata(const JsonDocument& doc) const {
-    ESP_LOGI(TAG, "_writeMetadata: Entry. Path=%s", _metadataFilePath); // Логирование входа
+    ESP_LOGD(TAG, "_writeMetadata: Entry. Path=%s", _metadataFilePath); // Логирование входа
     File metadataFile = _fs->open(_metadataFilePath, "w");
     if (!metadataFile) {
         ESP_LOGE(TAG, "_writeMetadata: Failed to open metadata file for writing: %s", _metadataFilePath); // Логирование ошибки
         return false;
     }
-    ESP_LOGI(TAG, "_writeMetadata: Metadata file opened for writing: %s", _metadataFilePath); // Логирование открытия файла
+    ESP_LOGD(TAG, "_writeMetadata: Metadata file opened for writing: %s", _metadataFilePath); // Логирование открытия файла
 
     if (serializeJson(doc, metadataFile) == 0) {
         ESP_LOGE(TAG, "_writeMetadata: Failed to write metadata to file: %s", _metadataFilePath); // Логирование ошибки
@@ -153,7 +153,7 @@ bool ProfileService::_writeMetadata(const JsonDocument& doc) const {
         return false;
     }
     metadataFile.close();
-    ESP_LOGI(TAG, "_writeMetadata: Metadata written successfully."); // Логирование записи
+    ESP_LOGD(TAG, "_writeMetadata: Metadata written successfully."); // Логирование записи
     return true;
 }
 
@@ -174,14 +174,14 @@ bool ProfileService::_getProfileMetadata(const String& profileId, JsonObject& pr
 
 bool ProfileService::_profileFileExists(const String& profileId) const {
     const String filePath = String(_profilesDir) + "/" + profileId + ".json";
-    ESP_LOGI(TAG, "_profileFileExists: Checking path=%s", filePath.c_str()); // Логирование проверки пути
+    ESP_LOGD(TAG, "_profileFileExists: Checking path=%s", filePath.c_str()); // Логирование проверки пути
     const bool exists = _fs->exists(filePath);
-    ESP_LOGI(TAG, "_profileFileExists: File %s exists: %s", filePath.c_str(), exists ? "true" : "false"); // Логирование результата
+    ESP_LOGD(TAG, "_profileFileExists: File %s exists: %s", filePath.c_str(), exists ? "true" : "false"); // Логирование результата
     return exists;
 }
 
 String ProfileService::_generateNewProfileId() const {
-    ESP_LOGI(TAG, "_generateNewProfileId: Entry"); // Логирование входа
+    ESP_LOGD(TAG, "_generateNewProfileId: Entry"); // Логирование входа
     JsonDocument metadataDoc(&s_profileJsonAllocator);
     if (!_readMetadata(metadataDoc)) {
         ESP_LOGW(TAG, "_generateNewProfileId: Failed to read metadata, initializing new array."); // Логирование предупреждения
@@ -226,7 +226,7 @@ String ProfileService::_generateNewProfileId() const {
     }
 
     String newId = String(maxNumericId + 1);
-    ESP_LOGI(TAG, "_generateNewProfileId: Generated new ID: %s", newId.c_str()); // Логирование сгенерированного ID
+    ESP_LOGD(TAG, "_generateNewProfileId: Generated new ID: %s", newId.c_str()); // Логирование сгенерированного ID
     return newId;
 }
 

--- a/lib/ssvcOpenConnect/core/rectification/RectificationProcess.cpp
+++ b/lib/ssvcOpenConnect/core/rectification/RectificationProcess.cpp
@@ -73,20 +73,17 @@ void RectificationProcess::begin(SsvcConnector& connector,
 
     while (true) {
         vTaskDelay(xDelay);
-        ESP_LOGD(TAG, "PressureSenderTask running...");
 
         if (self->currentProcessStatus == ProcessState::RUNNING) {
-            ESP_LOGD(TAG, "Rectification process is running. Checking for pressure sensor.");
+            ESP_LOGD(TAG, "Rectification running, checking pressure sensor.");
             const float relative_pressure = self->metric.common.relative_pressure;
             if (relative_pressure != 0.0f) { // Only send if there's a meaningful relative pressure
                 ESP_LOGD(TAG, "Sending relative pressure to SSVC: %.2f", relative_pressure);
                 SsvcSettings::Builder builder;
                 builder.setTankPressureActual(relative_pressure);
             } else {
-                ESP_LOGD(TAG, "Relative pressure is 0. Not sending.");
+                ESP_LOGV(TAG, "Relative pressure is 0. Not sending.");
             }
-        } else {
-            ESP_LOGD(TAG, "Rectification process is not running.");
         }
     }
 }

--- a/lib/ssvcOpenConnect/external/MqttBridge/MqttBridge.cpp
+++ b/lib/ssvcOpenConnect/external/MqttBridge/MqttBridge.cpp
@@ -71,7 +71,7 @@ uint16_t MqttBridge::publish(const char *topic, const char *payload, uint8_t qos
 
     if (!_settingsService->isEnabled())
     {
-        ESP_LOGW(TAG, "MQTT is disabled. Not publishing to %s with QoS %d", topic, qos);
+        ESP_LOGV(TAG, "MQTT disabled, skip publish to %s (QoS %d)", topic, qos);
         return 0;
     }
     if (!_settingsService->isConnected())

--- a/lib/ssvcOpenConnect/external/telegramm/TelegramBotClient.cpp
+++ b/lib/ssvcOpenConnect/external/telegramm/TelegramBotClient.cpp
@@ -11,8 +11,13 @@ constexpr time_t kMinValidSystemTime = 1704067200;  // 2024-01-01 UTC
 
 bool waitWifiConnected(uint32_t timeoutMs) {
     const uint32_t deadline = millis() + timeoutMs;
+    uint32_t lastLogMs = 0;
     while (!WiFi.isConnected() && millis() < deadline) {
-        ESP_LOGD("TelegramBotClient", "Waiting for WiFi...");
+        const uint32_t now = millis();
+        if (now - lastLogMs >= 30000) {
+            ESP_LOGV("TelegramBotClient", "Waiting for WiFi...");
+            lastLogMs = now;
+        }
         vTaskDelay(pdMS_TO_TICKS(1000));
     }
     return WiFi.isConnected();
@@ -20,8 +25,13 @@ bool waitWifiConnected(uint32_t timeoutMs) {
 
 bool waitSystemTime(uint32_t timeoutMs) {
     const uint32_t deadline = millis() + timeoutMs;
+    uint32_t lastLogMs = 0;
     while (time(nullptr) < kMinValidSystemTime && millis() < deadline) {
-        ESP_LOGD("TelegramBotClient", "Waiting for SNTP time sync...");
+        const uint32_t now = millis();
+        if (now - lastLogMs >= 30000) {
+            ESP_LOGV("TelegramBotClient", "Waiting for SNTP time sync...");
+            lastLogMs = now;
+        }
         vTaskDelay(pdMS_TO_TICKS(500));
     }
     const bool ok = time(nullptr) >= kMinValidSystemTime;

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,14 +47,14 @@ build_flags =
     ; These build flags are only for debugging purposes and should not be used in production
     -D CONFIG_ARDUHAL_LOG_COLORS
 
-	; Uncomment to show log messages from the ESP Arduino Core and ESP32-SvelteKit
-	-D CORE_DEBUG_LEVEL=4
+	; Global log verbosity (ESP_LOG*): 5=VERBOSE for level validation during development
+	-D CORE_DEBUG_LEVEL=3
 
  	; Serve config files from flash and access at /config/filename.json
     ;-D SERVE_CONFIG_FILES
 
     ; Uncomment to teleplot all task high watermarks to Serial
-	-D TELEPLOT_TASKS
+	; -D TELEPLOT_TASKS
 
     ; Uncomment to use JSON instead of MessagePack for event messages. Default is MessagePack.
     ; -D EVENT_USE_JSON=1


### PR DESCRIPTION
Reassign ESP_LOG levels for high-frequency paths (StatusLed, AlarmMonitor, RectificationProcess, MqttBridge, boot trace) and comment out TELEPLOT_TASKS so INFO-level monitor output focuses on state changes and errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized LED status updates to refresh only when device state changes, reducing unnecessary updates.

* **Chores**
  * Adjusted logging verbosity across components to reduce runtime output.
  * Disabled teleplot task logging in debug builds.
  * Fine-tuned debug log levels for initialization and monitoring processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SSVC0059/ssvc_open_connect/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->