### PR TITLE
fix(calculator): sync computed SSVC opening into data-path inputs

### DIFF
--- a/interface/src/calculator.js
+++ b/interface/src/calculator.js
@@ -5,6 +5,14 @@ import { DistillationCycleModel, createDefaultProfile } from '$lib/actions/Disti
 
 const CALC_ROOT_SELECTOR = '.editor-layout#app';
 
+/** Поля SSVC, которые модель пересчитывает и которые нужно показывать в инпутах (не только в analytics). */
+const SSVC_COMPUTED_INPUT_PATHS = [
+	'ssvcSettings.heads.0',
+	'ssvcSettings.late_heads.0',
+	'ssvcSettings.hearts.0',
+	'ssvcSettings.tails.0'
+];
+
 const model = new DistillationCycleModel();
 
 /** База дефолтов для текущей страницы калькулятора (пересоздаётся при каждом init). */
@@ -126,6 +134,20 @@ function initCalculator() {
 					el.textContent = formatResultText(path, value);
 				} else {
 					el.textContent = '';
+				}
+			});
+
+			SSVC_COMPUTED_INPUT_PATHS.forEach((path) => {
+				const value = getValueByPath(profile, path);
+				const input = r.querySelector(`[data-path="${path}"]`);
+				if (
+					input &&
+					input.type !== 'checkbox' &&
+					value !== null &&
+					value !== undefined &&
+					!Number.isNaN(value)
+				) {
+					input.value = value;
 				}
 			});
 

--- a/interface/tests/DistillationCycleModel.compiled.test.ts
+++ b/interface/tests/DistillationCycleModel.compiled.test.ts
@@ -25,6 +25,8 @@ function buildCalculatorFixtureHtml(): string {
                 <input type="checkbox" data-path="heads.enabled" checked>
                 <input type="number" data-path="heads.percent" value="3">
                 <input type="number" data-path="heads.targetCycles" value="2">
+                <input type="number" data-path="ssvcSettings.heads.0" value="0" step="0.1">
+                <input type="number" data-path="ssvcSettings.heads.1" value="120" step="1">
                 <input type="checkbox" data-path="late_heads.enabled" checked>
                 <input type="number" data-path="late_heads.percent" value="7">
                 <input type="number" data-path="hearts.percent" value="75">
@@ -87,6 +89,22 @@ describe('Compiled DistillationCycleModel Test', () => {
 
 		expect(totalASElement!.textContent).toBe('10000 мл');
 		expect(console.error).not.toHaveBeenCalled();
+	});
+
+	it('should sync computed SSVC opening time into data-path inputs after calculate', () => {
+		const openingInput = document.querySelector<HTMLInputElement>('[data-path="ssvcSettings.heads.0"]');
+		const powerInput = document.querySelector<HTMLInputElement>('[data-path="powerKw"]');
+
+		expect(openingInput).toBeTruthy();
+		const openingAfterInit = Number(openingInput!.value);
+		expect(openingAfterInit).toBeGreaterThan(0);
+
+		powerInput!.value = '4';
+		powerInput!.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+		const openingAfterPowerChange = Number(openingInput!.value);
+		expect(openingAfterPowerChange).toBeGreaterThan(0);
+		expect(openingAfterPowerChange).not.toBe(openingAfterInit);
 	});
 
 	it('should reset to defaults when reset-all-btn is clicked', () => {

--- a/interface/tests/DistillationCycleModel.full.test.ts
+++ b/interface/tests/DistillationCycleModel.full.test.ts
@@ -228,6 +228,22 @@ describe('DistillationCycleModel: дефолтный профиль и опци�
 		expect(result.analytics.flows.heads).toBe(2000);
 		expect(result.analytics.flows.heads_final).toBe(7000);
 	});
+
+	it('время открытия клапана голов (ssvcSettings.heads[0]) зависит от мощности', () => {
+		const low = createDefaultProfile();
+		low.powerKw = 2;
+		const high = createDefaultProfile();
+		high.powerKw = 4;
+
+		const rLow = model.calculateProcess(low);
+		const rHigh = model.calculateProcess(high);
+
+		expect(rLow.ssvcSettings.heads[0]).toBeGreaterThan(0);
+		expect(rHigh.ssvcSettings.heads[0]).toBeGreaterThan(0);
+		expect(rHigh.ssvcSettings.heads[0]).not.toBe(rLow.ssvcSettings.heads[0]);
+		// Период цикла — ввод пользователя, модель его не пересчитывает
+		expect(rHigh.ssvcSettings.heads[1]).toBe(rLow.ssvcSettings.heads[1]);
+	});
 });
 
 describe('DistillationCycleModel Edge Cases', () => {


### PR DESCRIPTION
GitLab Pages calculator updated only data-result nodes; SSVC opening fields stayed at defaults after recalculate. Add write-back and tests.

Fixes SSVC0059/ssvc_open_connect#141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calculator inputs now display updated SSVC-computed values after calculations.
  * SSVC heads opening time updates automatically when the configured power changes.
  * User-provided SSVC cycle period values remain unchanged during recalculation.

* **Tests**
  * Added coverage to verify SSVC timing synchronization and recalculation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->